### PR TITLE
fix: keep detail sheet presented when changing day

### DIFF
--- a/ImperialWeather.xcodeproj/project.pbxproj
+++ b/ImperialWeather.xcodeproj/project.pbxproj
@@ -91,7 +91,6 @@
 		F88804762C3FDF7A005637F9 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88804752C3FDF6C005637F9 /* APIClient.swift */; };
 		F888047C2C402762005637F9 /* MockURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F888047B2C40275B005637F9 /* MockURLProtocol.swift */; };
 		F888047E2C4027C6005637F9 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F888047D2C4027C2005637F9 /* APIClientTests.swift */; };
-		F88DC0B2299655C80029E1F4 /* SwiftUINavigation in Frameworks */ = {isa = PBXBuildFile; productRef = F88DC0B1299655C80029E1F4 /* SwiftUINavigation */; };
 		F890ECB12FA0B861007E8217 /* Color+MaterialTint.swift in Sources */ = {isa = PBXBuildFile; fileRef = F890ECB02FA0B85B007E8217 /* Color+MaterialTint.swift */; };
 		F89722372C41342200C66322 /* MockRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89722362C41341900C66322 /* MockRequest.swift */; };
 		F897223B2C41BDC500C66322 /* LocationPlain.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897223A2C41BDC200C66322 /* LocationPlain.swift */; };
@@ -339,7 +338,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F88DC0B2299655C80029E1F4 /* SwiftUINavigation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -833,7 +831,6 @@
 			);
 			name = ImperialWeather;
 			packageProductDependencies = (
-				F88DC0B1299655C80029E1F4 /* SwiftUINavigation */,
 			);
 			productName = ImperialWeather;
 			productReference = F87E5C8F267C9E950032949A /* ImperialWeather.app */;
@@ -873,7 +870,6 @@
 			);
 			mainGroup = F87E5C86267C9E950032949A;
 			packageReferences = (
-				F88DC0B0299655C80029E1F4 /* XCRemoteSwiftPackageReference "swiftui-navigation" */,
 				F8B993372C4918B500F326CE /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 			);
 			productRefGroup = F87E5C90267C9E950032949A /* Products */;
@@ -1443,14 +1439,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		F88DC0B0299655C80029E1F4 /* XCRemoteSwiftPackageReference "swiftui-navigation" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swiftui-navigation";
-			requirement = {
-				branch = main;
-				kind = branch;
-			};
-		};
 		F8B993372C4918B500F326CE /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins.git";
@@ -1462,11 +1450,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		F88DC0B1299655C80029E1F4 /* SwiftUINavigation */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = F88DC0B0299655C80029E1F4 /* XCRemoteSwiftPackageReference "swiftui-navigation" */;
-			productName = SwiftUINavigation;
-		};
 		F8B993382C491B0100F326CE /* SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F8B993372C4918B500F326CE /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;

--- a/ImperialWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ImperialWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,33 +1,6 @@
 {
-  "originHash" : "c57fb621837d82c3db7edaba4aae405c74cde2a72b7f108476e1464ecffe2714",
+  "originHash" : "ae94d77b3cab58245ed9263e61d40af9694885616f7792aa7c3480acc2cc933c",
   "pins" : [
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
-        "version" : "1.7.3"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
-        "version" : "603.0.1"
-      }
-    },
     {
       "identity" : "swiftlintplugins",
       "kind" : "remoteSourceControl",
@@ -35,24 +8,6 @@
       "state" : {
         "revision" : "8a4640d14777685ba8f14e832373160498fbab92",
         "version" : "0.63.2"
-      }
-    },
-    {
-      "identity" : "swiftui-navigation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swiftui-navigation",
-      "state" : {
-        "branch" : "main",
-        "revision" : "f0fd51da3d1edc564550d151eee9bd83b0ff221f"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/ImperialWeather/Home/Framework/Views/WeatherDetail/WeatherDetailView.swift
+++ b/ImperialWeather/Home/Framework/Views/WeatherDetail/WeatherDetailView.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 struct WeatherDetailView: View {
     let dailyWeather: [DailyWeather]
-    @Binding var selection: DailyWeather
+    @State private var selection: DailyWeather
     @Environment(\.dismiss) private var dismiss
+
+    init(dailyWeather: [DailyWeather], initialSelection: DailyWeather) {
+        self.dailyWeather = dailyWeather
+        self._selection = State(initialValue: initialSelection)
+    }
 
     var body: some View {
         NavigationView {
@@ -79,6 +84,6 @@ struct WeatherDetailView: View {
 #Preview {
     WeatherDetailView(
         dailyWeather: .preview,
-        selection: .constant(.todayPreview)
+        initialSelection: .todayPreview
     )
 }

--- a/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
+++ b/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
@@ -32,9 +32,9 @@ struct DailyWeatherView: View {
                         .contentShape(Rectangle())
                 }
                 .tint(.primary)
-                .sheet(item: self.$selection) { $selection in
-                    WeatherDetailView(dailyWeather: dailyWeather, selection: $selection)
-                }
+            }
+            .sheet(item: self.$selection) { $selection in
+                WeatherDetailView(dailyWeather: dailyWeather, selection: $selection)
             }
         }
         .paneBackground()

--- a/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
+++ b/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
@@ -33,8 +33,8 @@ struct DailyWeatherView: View {
                 }
                 .tint(.primary)
             }
-            .sheet(item: self.$selection) { $selection in
-                WeatherDetailView(dailyWeather: dailyWeather, selection: $selection)
+            .sheet(item: self.$selection) { selection in
+                WeatherDetailView(dailyWeather: dailyWeather, initialSelection: selection)
             }
         }
         .paneBackground()

--- a/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
+++ b/ImperialWeather/Home/Framework/Views/WeatherHome/DailyWeatherView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftUINavigation
 
 struct DailyWeatherView: View {
     let dailyWeather: [DailyWeather]


### PR DESCRIPTION
Fixes #11

The detail sheet was driven by `.sheet(item:)` bound to the same state the
week picker mutates. Selecting a new day replaced the item, changing its
identity, so SwiftUI dismissed and re-presented the sheet on every change.

## Changes
- `WeatherDetailView` now owns its day selection as local `@State`, seeded
  from the tapped day; the sheet item never changes while presented
- Moved `.sheet` out of the `ForEach` in `DailyWeatherView` (one modifier
  instead of seven)
- Removed the SwiftUINavigation package — the binding-based sheet API was
  its only use; drops 5 transitive pins including swift-syntax

## Testing
- Manually verified on iPhone 17 Pro simulator (iOS 26.0): changing days
  in the week picker updates content in place, sheet stays presented;
  swipe-down and Close button both still dismiss
- CI (lint + tests) green